### PR TITLE
Implement API for Clientes with permissions and tests

### DIFF
--- a/backend/miproyecto_django/apps/clientes/permissions.py
+++ b/backend/miproyecto_django/apps/clientes/permissions.py
@@ -1,0 +1,15 @@
+from rest_framework.permissions import BasePermission, SAFE_METHODS
+
+
+class IsAdminOrVendedor(BasePermission):
+    """Permite modificar solo a usuarios con rol admin o vendedor."""
+
+    def has_permission(self, request, view):
+        if not request.user or not request.user.is_authenticated:
+            return False
+        if request.method in SAFE_METHODS:
+            return True
+        rol = getattr(getattr(request.user, 'rol', None), 'nombre', None)
+        if rol in {'admin', 'vendedor'} or request.user.is_staff or request.user.is_superuser:
+            return True
+        return False

--- a/backend/miproyecto_django/apps/clientes/serializers.py
+++ b/backend/miproyecto_django/apps/clientes/serializers.py
@@ -1,0 +1,25 @@
+from rest_framework import serializers
+from .models import Cliente
+
+
+class ClienteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Cliente
+        fields = '__all__'
+        read_only_fields = ('created_at', 'updated_at')
+
+    def validate_dni(self, value: str) -> str:
+        qs = Cliente.objects.filter(dni=value)
+        if self.instance:
+            qs = qs.exclude(pk=self.instance.pk)
+        if qs.exists():
+            raise serializers.ValidationError('Cliente con este DNI ya existe.')
+        return value
+
+    def validate_email(self, value: str) -> str:
+        qs = Cliente.objects.filter(email=value)
+        if self.instance:
+            qs = qs.exclude(pk=self.instance.pk)
+        if qs.exists():
+            raise serializers.ValidationError('Cliente con este email ya existe.')
+        return value

--- a/backend/miproyecto_django/apps/clientes/tests/test_clientes.py
+++ b/backend/miproyecto_django/apps/clientes/tests/test_clientes.py
@@ -1,0 +1,112 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.clientes.models import Cliente
+from apps.user.models import CustomUser, Rol
+
+
+class ClienteAPITestCase(APITestCase):
+    def setUp(self):
+        admin_role = Rol.objects.create(nombre='admin')
+        vendedor_role = Rol.objects.create(nombre='vendedor')
+        viewer_role = Rol.objects.create(nombre='viewer')
+
+        self.admin_user = CustomUser.objects.create_user(
+            email='admin@example.com', first_name='Admin', last_name='User',
+            password='adminpass', rol=admin_role
+        )
+        self.vendedor_user = CustomUser.objects.create_user(
+            email='vendor@example.com', first_name='Vendor', last_name='User',
+            password='vendorpass', rol=vendedor_role
+        )
+        self.viewer_user = CustomUser.objects.create_user(
+            email='viewer@example.com', first_name='Viewer', last_name='User',
+            password='viewerpass', rol=viewer_role
+        )
+
+        self.list_url = '/api/v1/clientes/clientes/'
+
+    def get_auth_header(self, user):
+        token = RefreshToken.for_user(user)
+        return {'HTTP_AUTHORIZATION': f'Bearer {token.access_token}'}
+
+    def test_crear_cliente_valido(self):
+        data = {
+            'nombre': 'Juan',
+            'apellido': 'Perez',
+            'dni': '12345678',
+            'telefono': '123456',
+            'email': 'juan@example.com',
+            'direccion': 'Calle 1',
+            'saldo': '0.00'
+        }
+        response = self.client.post(self.list_url, data, **self.get_auth_header(self.admin_user))
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Cliente.objects.count(), 1)
+
+    def test_crear_cliente_dni_duplicado(self):
+        Cliente.objects.create(nombre='a', apellido='b', dni='111', telefono='0', email='a@a.com', direccion='x')
+        data = {
+            'nombre': 'Otro',
+            'apellido': 'Test',
+            'dni': '111',
+            'telefono': '123',
+            'email': 'otro@example.com',
+            'direccion': 'Calle 2'
+        }
+        response = self.client.post(self.list_url, data, **self.get_auth_header(self.admin_user))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_crear_cliente_email_duplicado(self):
+        Cliente.objects.create(nombre='a', apellido='b', dni='222', telefono='0', email='dup@example.com', direccion='x')
+        data = {
+            'nombre': 'Otro',
+            'apellido': 'Test',
+            'dni': '333',
+            'telefono': '123',
+            'email': 'dup@example.com',
+            'direccion': 'Calle 2'
+        }
+        response = self.client.post(self.list_url, data, **self.get_auth_header(self.admin_user))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_listar_clientes(self):
+        Cliente.objects.create(nombre='a', apellido='b', dni='1', telefono='0', email='a@a.com', direccion='x')
+        Cliente.objects.create(nombre='c', apellido='d', dni='2', telefono='0', email='c@c.com', direccion='y')
+        response = self.client.get(self.list_url, **self.get_auth_header(self.viewer_user))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 2)
+
+    def test_filtrar_por_nombre(self):
+        Cliente.objects.create(nombre='Ana', apellido='b', dni='1', telefono='0', email='a@a.com', direccion='x')
+        Cliente.objects.create(nombre='Beto', apellido='c', dni='2', telefono='0', email='b@b.com', direccion='y')
+        response = self.client.get(f'{self.list_url}?search=Ana', **self.get_auth_header(self.viewer_user))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['nombre'], 'Ana')
+
+    def test_actualizar_cliente(self):
+        cliente = Cliente.objects.create(nombre='Ana', apellido='b', dni='99', telefono='0', email='ana@a.com', direccion='x')
+        data = {'nombre': 'Ana Maria'}
+        url = f'{self.list_url}{cliente.id}/'
+        response = self.client.patch(url, data, **self.get_auth_header(self.vendedor_user))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        cliente.refresh_from_db()
+        self.assertEqual(cliente.nombre, 'Ana Maria')
+
+    def test_eliminar_cliente(self):
+        cliente = Cliente.objects.create(nombre='Ana', apellido='b', dni='88', telefono='0', email='del@a.com', direccion='x')
+        url = f'{self.list_url}{cliente.id}/'
+        response = self.client.delete(url, **self.get_auth_header(self.admin_user))
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(Cliente.objects.count(), 0)
+
+    def test_permiso_usuario_no_autorizado(self):
+        data = {
+            'nombre': 'Sin', 'apellido': 'Permiso', 'dni': '777',
+            'telefono': '0', 'email': 'sin@permiso.com', 'direccion': 'x'
+        }
+        response = self.client.post(self.list_url, data, **self.get_auth_header(self.viewer_user))
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/backend/miproyecto_django/apps/clientes/urls.py
+++ b/backend/miproyecto_django/apps/clientes/urls.py
@@ -1,5 +1,7 @@
-from django.urls import path
+from rest_framework.routers import DefaultRouter
+from .views import ClienteViewSet
 
-urlpatterns = [
+router = DefaultRouter()
+router.register(r'clientes', ClienteViewSet, basename='cliente')
 
-]
+urlpatterns = router.urls

--- a/backend/miproyecto_django/apps/clientes/views.py
+++ b/backend/miproyecto_django/apps/clientes/views.py
@@ -1,3 +1,20 @@
-from django.shortcuts import render
+from rest_framework import viewsets, filters
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.pagination import PageNumberPagination
+from rest_framework_simplejwt.authentication import JWTAuthentication
 
-# Create your views here.
+from .models import Cliente
+from .serializers import ClienteSerializer
+from .permissions import IsAdminOrVendedor
+
+
+class ClienteViewSet(viewsets.ModelViewSet):
+    queryset = Cliente.objects.all()
+    serializer_class = ClienteSerializer
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAuthenticated, IsAdminOrVendedor]
+    pagination_class = PageNumberPagination
+
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ['nombre', 'apellido', 'dni']
+    ordering_fields = ['nombre', 'created_at']


### PR DESCRIPTION
## Summary
- implement `ClienteSerializer` with unique field validation
- add `IsAdminOrVendedor` permission class
- implement `ClienteViewSet` with JWT auth, filters and pagination
- register viewset in app urls
- add API tests for Clientes actions

## Testing
- `python manage.py test apps.clientes.tests.test_clientes -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68411e3c8a2c832d91ca0c2decb75319