### PR TITLE
Refactor text cleaning into shared util

### DIFF
--- a/backend/miproyecto_django/apps/stock/models.py
+++ b/backend/miproyecto_django/apps/stock/models.py
@@ -3,14 +3,8 @@ from django.core.exceptions import ValidationError
 from datetime import date
 from apps.empresa.models import Almacen
 from apps.user.models import CustomUser
-import unicodedata
+from .utils import limpiar_texto
 
-def limpiar_texto(texto):
-    if texto is None:
-        return ''
-    texto = texto.strip()
-    texto = unicodedata.normalize('NFKD', texto).encode('ASCII', 'ignore').decode('utf-8')
-    return texto.lower()
 
 class Categoria(models.Model):
     nombre = models.CharField(max_length=100, default='General', unique=True)

--- a/backend/miproyecto_django/apps/stock/utils.py
+++ b/backend/miproyecto_django/apps/stock/utils.py
@@ -1,0 +1,9 @@
+import pandas as pd
+from unidecode import unidecode
+
+
+def limpiar_texto(valor):
+    """Normaliza y limpia cadenas de texto."""
+    if valor is None or pd.isnull(valor):
+        return ""
+    return unidecode(str(valor).strip()).lower()

--- a/backend/miproyecto_django/apps/stock/views.py
+++ b/backend/miproyecto_django/apps/stock/views.py
@@ -1,13 +1,11 @@
-from django.shortcuts import render
-from rest_framework import viewsets
 from .serializers import CategoriaSerializer, SubcategoriaSerializer, ProductoSerializer, MovimientoStockSerializer
 from rest_framework.permissions import IsAuthenticated
 import pandas as pd
-from unidecode import unidecode
 from rest_framework.views import APIView
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework import viewsets
 from .models import Producto, Categoria, Subcategoria, MovimientoStock
 from apps.empresa.models import Almacen
 from apps.proveedores.models import Proveedor, Compra
@@ -16,7 +14,7 @@ from .filters import ProductoFilter
 import openpyxl
 from openpyxl.utils import get_column_letter
 from django.http import HttpResponse
-from .models import Producto
+from .utils import limpiar_texto
 
 
 class ProductoViewSet(viewsets.ModelViewSet):
@@ -41,12 +39,6 @@ class MovimientoStockViewSet(viewsets.ModelViewSet):
     queryset = MovimientoStock.objects.all()
     serializer_class = MovimientoStockSerializer
     permission_classes = [IsAuthenticated]
-
-
-def limpiar_texto(valor):
-    if pd.isnull(valor):
-        return ''
-    return unidecode(str(valor).strip().lower())
 
 class CargaMasivaProductosView(APIView):
     parser_classes = [MultiPartParser]


### PR DESCRIPTION
## Summary
- centralize `limpiar_texto` helper in `apps/stock/utils.py`
- update stock models and views to import the shared utility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684126c8a1e4832d9208f84ad66252fc