### PR TITLE
Fix imports across apps

### DIFF
--- a/backend/miproyecto_django/apps/user/urls.py
+++ b/backend/miproyecto_django/apps/user/urls.py
@@ -5,10 +5,10 @@ Enrutado de la app users.
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
-from users.views.auth_views import RegisterView, LoginView, LogoutView
-from users.views.user_views import UserViewSet
-from users.views.role_views import RoleViewSet
-from users.views.permission_views import PermissionListView
+from apps.user.views.auth_views import RegisterView, LoginView, LogoutView
+from apps.user.views.user_views import UserViewSet
+from apps.user.views.role_views import RoleViewSet
+from apps.user.views.permissions_views import PermissionListView
 
 router = DefaultRouter()
 router.register(r"usuarios", UserViewSet, basename="usuario")

--- a/backend/miproyecto_django/apps/user/views/auth_views.py
+++ b/backend/miproyecto_django/apps/user/views/auth_views.py
@@ -3,12 +3,13 @@ Vistas de autenticación: registro, login y logout.
 """
 
 from django.contrib.auth import authenticate
+from django.conf import settings
 from rest_framework import generics, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_simplejwt.tokens import RefreshToken
 
-from users.serializers import RegisterSerializer, UserSerializer
+from apps.user.serializers import RegisterSerializer, UserSerializer
 
 ACCESS_COOKIE = "access_token"
 REFRESH_COOKIE = "refresh_token"
@@ -45,11 +46,11 @@ class LoginView(APIView):
         # Guardar cookies seguras
         resp.set_cookie(
             ACCESS_COOKIE, str(access), httponly=True, samesite="Lax",
-            secure=not request.settings.DEBUG, path="/"
+            secure=not settings.DEBUG, path="/"
         )
         resp.set_cookie(
             REFRESH_COOKIE, str(refresh), httponly=True, samesite="Lax",
-            secure=not request.settings.DEBUG, path="/"
+            secure=not settings.DEBUG, path="/"
         )
         return resp
 

--- a/backend/miproyecto_django/apps/user/views/permissions_views.py
+++ b/backend/miproyecto_django/apps/user/views/permissions_views.py
@@ -5,8 +5,8 @@ Vista de solo lectura para listar todos los permisos disponibles.
 from django.contrib.auth.models import Permission
 from rest_framework import generics
 
-from users.serializers import PermissionSerializer
-from users.permissions import IsAdminOrHasPermission
+from apps.user.serializers import PermissionSerializer
+from apps.user.permissions import IsAdminOrHasPermission
 
 
 class PermissionListView(generics.ListAPIView):

--- a/backend/miproyecto_django/apps/user/views/role_views.py
+++ b/backend/miproyecto_django/apps/user/views/role_views.py
@@ -4,13 +4,13 @@ ViewSet para CRUD de roles.
 
 from rest_framework import viewsets
 
-from users.permissions import IsAdminOrHasPermission
-from users.serializers import (
-    RoleSerializer,
-    RoleDetailSerializer,
-    RolePermissionUpdateSerializer,
+from apps.user.permissions import IsAdminOrHasPermission
+from apps.user.serializers import (
+    RolSerializer,
+    RolDetailSerializer,
+    RolPermisosUpdateSerializer,
 )
-from users.models import Role
+from apps.user.models import Rol
 
 
 class RoleViewSet(viewsets.ModelViewSet):
@@ -18,8 +18,8 @@ class RoleViewSet(viewsets.ModelViewSet):
     CRUD de roles y asignación de permisos.
     """
 
-    queryset = Role.objects.prefetch_related("permisos")
-    serializer_class = RoleSerializer
+    queryset = Rol.objects.prefetch_related("permisos")
+    serializer_class = RolSerializer
     permission_classes = [IsAdminOrHasPermission]
 
     permission_map = {
@@ -34,13 +34,13 @@ class RoleViewSet(viewsets.ModelViewSet):
 
     def get_serializer_class(self):
         if self.action in {"retrieve", "update", "partial_update"}:
-            return RoleDetailSerializer
+            return RolDetailSerializer
         return super().get_serializer_class()
 
     # Acción extra para asignar permisos
     def set_permissions(self, request, pk=None):
         role = self.get_object()
-        serializer = RolePermissionUpdateSerializer(data=request.data)
+        serializer = RolPermisosUpdateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         role.permisos.set(serializer.validated_data["permisos"])
         return Response({"detail": "Permisos asignados."})

--- a/backend/miproyecto_django/apps/user/views/user_views.py
+++ b/backend/miproyecto_django/apps/user/views/user_views.py
@@ -5,8 +5,8 @@ ViewSet para CRUD de usuarios.
 from django.contrib.auth import get_user_model
 from rest_framework import viewsets
 
-from users.permissions import IsAdminOrHasPermission
-from users.serializers import (
+from apps.user.permissions import IsAdminOrHasPermission
+from apps.user.serializers import (
     UserSerializer,
     UserDetailSerializer,
     UserPermissionUpdateSerializer,

--- a/backend/miproyecto_django/apps/ventas/views.py
+++ b/backend/miproyecto_django/apps/ventas/views.py
@@ -1,8 +1,11 @@
 from rest_framework import viewsets, permissions
+from rest_framework.exceptions import ValidationError
+from django_filters.rest_framework import DjangoFilterBackend
+
 from .models import Venta
 from .serializers import VentaSerializer
 from .filters import VentaFilter
-from django_filters.rest_framework import DjangoFilterBackend
+from apps.caja.models import Caja, MovimientoCaja
 
 class VentaViewSet(viewsets.ModelViewSet):
     queryset = Venta.objects.all().order_by('-fecha')

--- a/backend/miproyecto_django/miproyecto_django/settings.py
+++ b/backend/miproyecto_django/miproyecto_django/settings.py
@@ -69,7 +69,7 @@ MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
 
     # ⬇️  Nuestro middleware
-    'users.middleware.JWTAuthenticationFromCookieMiddleware',
+    'apps.user.middleware.JWTAuthenticationFromCookieMiddleware',
 
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
## Summary
- update middleware path in settings
- correct import paths in user views and urls
- adjust role view to use updated serializer/model names
- fix login view cookie security reference
- add missing imports to sales view

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6842b8fa80dc832da086f4eeac09f7ec