### PR TITLE
Add admin configurations for Django apps

### DIFF
--- a/backend/miproyecto_django/apps/caja/admin.py
+++ b/backend/miproyecto_django/apps/caja/admin.py
@@ -1,3 +1,28 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import Caja, MovimientoCaja
+
+
+@admin.register(Caja)
+class CajaAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "usuario",
+        "fecha_apertura",
+        "fecha_cierre",
+        "monto_inicial",
+        "monto_final",
+        "abierta",
+    )
+    list_filter = ("abierta", "usuario")
+    search_fields = ("usuario__email",)
+    date_hierarchy = "fecha_apertura"
+
+
+@admin.register(MovimientoCaja)
+class MovimientoCajaAdmin(admin.ModelAdmin):
+    list_display = ("id", "caja", "fecha", "tipo", "monto", "descripcion")
+    list_filter = ("tipo",)
+    search_fields = ("descripcion",)
+    date_hierarchy = "fecha"
+

--- a/backend/miproyecto_django/apps/clientes/admin.py
+++ b/backend/miproyecto_django/apps/clientes/admin.py
@@ -1,0 +1,16 @@
+from django.contrib import admin
+
+from .models import Cliente
+
+
+@admin.register(Cliente)
+class ClienteAdmin(admin.ModelAdmin):
+    list_display = (
+        "nombre",
+        "apellido",
+        "dni",
+        "telefono",
+        "email",
+        "saldo",
+    )
+    search_fields = ("nombre", "apellido", "dni", "email")

--- a/backend/miproyecto_django/apps/proveedores/admin.py
+++ b/backend/miproyecto_django/apps/proveedores/admin.py
@@ -1,7 +1,31 @@
 from django.contrib import admin
-from .models import Proveedor
+from .models import Proveedor, Compra, DetalleCompra
 
 @admin.register(Proveedor)
 class ProveedorAdmin(admin.ModelAdmin):
     list_display = ('nombre', 'telefono', 'email')
     search_fields = ('nombre', 'telefono', 'email')
+
+
+class DetalleCompraInline(admin.TabularInline):
+    model = DetalleCompra
+    extra = 0
+
+
+@admin.register(Compra)
+class CompraAdmin(admin.ModelAdmin):
+    list_display = ('id', 'proveedor', 'fecha', 'total', 'almacen')
+    list_filter = ('fecha', 'proveedor')
+    search_fields = ('proveedor__nombre',)
+    date_hierarchy = 'fecha'
+    inlines = [DetalleCompraInline]
+
+
+@admin.register(DetalleCompra)
+class DetalleCompraAdmin(admin.ModelAdmin):
+    list_display = (
+        'compra',
+        'producto',
+        'cantidad',
+        'precio_unitario',
+    )

--- a/backend/miproyecto_django/apps/stock/admin.py
+++ b/backend/miproyecto_django/apps/stock/admin.py
@@ -1,7 +1,14 @@
 from django.contrib import admin
-from .models import Categoria, Subcategoria, Producto, MovimientoStock 
+from .models import (
+    Categoria,
+    Subcategoria,
+    Producto,
+    MovimientoStock,
+    AlertaSistema,
+)
 
 admin.site.register(Categoria)
 admin.site.register(Subcategoria)
 admin.site.register(Producto)
 admin.site.register(MovimientoStock)
+admin.site.register(AlertaSistema)

--- a/backend/miproyecto_django/apps/user/admin.py
+++ b/backend/miproyecto_django/apps/user/admin.py
@@ -1,0 +1,20 @@
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+
+from .models import Rol, Usuario
+
+
+@admin.register(Rol)
+class RolAdmin(admin.ModelAdmin):
+    list_display = ("nombre",)
+    search_fields = ("nombre",)
+
+
+@admin.register(Usuario)
+class UsuarioAdmin(BaseUserAdmin):
+    list_display = ("email", "username", "rol", "is_staff")
+    list_filter = ("is_staff", "is_superuser", "rol")
+    search_fields = ("email", "username")
+    fieldsets = BaseUserAdmin.fieldsets + (
+        ("Datos adicionales", {"fields": ("rol", "permisos_adicionales")}),
+    )

--- a/backend/miproyecto_django/apps/ventas/admin.py
+++ b/backend/miproyecto_django/apps/ventas/admin.py
@@ -1,3 +1,29 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import Venta, DetalleVenta
+
+
+class DetalleVentaInline(admin.TabularInline):
+    model = DetalleVenta
+    extra = 0
+
+
+@admin.register(Venta)
+class VentaAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "fecha",
+        "cliente",
+        "usuario",
+        "total",
+        "confirmado",
+    )
+    list_filter = ("tipo_documento", "confirmado", "fecha")
+    search_fields = ("cliente__nombre", "cliente__apellido", "id")
+    date_hierarchy = "fecha"
+    inlines = [DetalleVentaInline]
+
+
+@admin.register(DetalleVenta)
+class DetalleVentaAdmin(admin.ModelAdmin):
+    list_display = ("venta", "producto", "cantidad", "precio_unitario", "subtotal")


### PR DESCRIPTION
## Summary
- complete admin registration for caja, clientes, user and ventas apps
- register missing models in stock and proveedores apps

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6842cb612574832d94ea4a9509ba3e78